### PR TITLE
Follow lib keys updated in RF

### DIFF
--- a/ThemeManager.roboFontExt/info.plist
+++ b/ThemeManager.roboFontExt/info.plist
@@ -28,8 +28,8 @@
 	<key>requiresVersionMinor</key>
 	<string>1</string>
 	<key>timeStamp</key>
-	<real>1669732507.7688589</real>
+	<real>1670968624.541971</real>
 	<key>version</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 </dict>
 </plist>

--- a/ThemeManager.roboFontExt/lib/ThemeManager.py
+++ b/ThemeManager.roboFontExt/lib/ThemeManager.py
@@ -42,15 +42,15 @@ THEMEKEYS = [
     ("glyphViewTangentPointsFill", "Tangent Fill Color", tuple),
     ("glyphViewTangentPointsStroke", "Tangent Stroke Color", tuple),
     ("glyphViewOffCurvePointsFill", "Offcurve Fill Color", tuple),
-    ("glyphViewOffCurvePointsStroke", "Offcurve Stroke Color (Cubic Beziers, PostScript)", tuple),
+    ("glyphViewOffCurveCubicPointsStroke", "Offcurve Stroke Color (Cubic Beziers, PostScript)", tuple),
     ("glyphViewOffCurveQuadPointsStroke", "Offcurve Stroke Color (Quadratic Beziers, TrueType)", tuple),
     ("glyphViewSmoothPointStroke", "Smooth Point Color", tuple),
     ("glyphViewComponentFillColor", "Component Fill Color", tuple),
     ("glyphViewComponentStrokeColor", "Component Stroke Color", tuple),
     ("glyphViewComponentInfoColor", "Component Info Text Color", tuple),
     ("glyphViewImageInfoColor", "Image Info Text Color", tuple),
-    ("glyphViewHandlesStrokeColor", "Handle Stroke Color (Cubic Beziers, PostScript)", tuple),
-    ("glyphViewHandlesQuadStrokeColor", "Handle Stroke Color (Quadratic Beziers, TrueType)", tuple),
+    ("glyphViewCubicHandlesStrokeColor", "Handle Stroke Color (Cubic Beziers, PostScript)", tuple),
+    ("glyphViewQuadraticHandlesStrokeColor", "Handle Stroke Color (Quadratic Beziers, TrueType)", tuple),
     ("glyphViewStartPointsArrowColor", "Start Point Arrow Color for closed contour", tuple),
     ("glyphViewOpenStartPointsArrowColor", "Start Point Arrow Color for an open contour", tuple),
     ("glyphViewSelectionColor", "Selection Color", tuple),
@@ -64,13 +64,13 @@ THEMEKEYS = [
     ("glyphViewAnchorColor", "Anchor Color", tuple),
     ("glyphViewAnchorTextColor", "Anchor Text Color", tuple),
     ("glyphViewMarginColor", "Margins Background Color", tuple),
-    ("glyphViewMetricsColor", "Vertical Metrics Color", tuple),
+    ("glyphViewFontMetricsStrokeColor", "Vertical Metrics Color", tuple),
     ("glyphViewMetricsTitlesColor", "Vertical Metrics Titles Color", tuple),
     ("glyphViewGridColor", "Grid Color", tuple),
     ("glyphViewBitmapColor", "Bitmap Color", tuple),
     ("glyphViewOutlineErrorsColor", "Line Straightness Indicator Color", tuple),
     ("glyphViewMeasurementsTextColor", "Measurements Text Color", tuple),
-    ("glyphViewMeasurementsForgroundColor", "Measurements Line Color", tuple),
+    ("glyphViewMeasurementsForegroundColor", "Measurements Line Color", tuple),
     ("glyphViewMeasurementsBackgroundColor", "Measurements Secondary Line Color", tuple),
     ("glyphViewContourIndexColor", "Contour Index Text Color", tuple),
     ("glyphViewSegmentIndexColor", "Segment Index Text Color", tuple),
@@ -241,13 +241,14 @@ class ThemeManager(BaseWindowController):
         # Collect the theme data for the selected theme and set it to the editingList
         if self.debug: print("setEditingList")
         listItems = []
+        fallbackColor = [.5, .5, .5, .5]
         for nameKey, name, valueType in THEMEKEYS:
             if valueType == tuple:
-                color = theme[nameKey]
+                color = theme.get(nameKey, fallbackColor)
                 listItem = {
-                        'color' : NSColor.colorWithCalibratedRed_green_blue_alpha_(*color),
-                        'name'  : name,
-                        'nameKey' : nameKey}
+                    'color': NSColor.colorWithCalibratedRed_green_blue_alpha_(*color),
+                    'name': name,
+                    'nameKey': nameKey}
                 listItems.append(listItem)
             else:
                 value = theme[nameKey]

--- a/ThemeManager.roboFontExt/lib/defconAppKitBranch/glyphView.py
+++ b/ThemeManager.roboFontExt/lib/defconAppKitBranch/glyphView.py
@@ -50,6 +50,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
         self._verticalCenterYBuffer = 100
 
         self._backgroundColor = NSColor.whiteColor()
+        self._fallbackColor = [.5, .5, .5, .5]
 
         return self
 
@@ -158,7 +159,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
     # ---------------
     # Display Control
     # ---------------
-    
+
     @python_method
     def setTheme(self, theme):
         self._theme = theme
@@ -280,7 +281,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
 
         yOffset = self._verticalCenterYBuffer * self._inverseScale
         yOffset -= self._descender
-        
+
         # @@@
         yOffset -= 270
         xOffset += 130
@@ -342,7 +343,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
     def drawBackground(self):
         if "glyphViewBackgroundColor" in self._theme:
             self._backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
-        else: 
+        else:
             self._backgroundColor = NSColor.whiteColor()
         self._backgroundColor.set()
         NSRectFill(self.bounds())
@@ -365,14 +366,16 @@ class DefconAppKitGlyphThemeNSView(NSView):
 
     @python_method
     def drawVerticalMetrics(self, glyph, layerName):
-        colorMetrics = drawing.colorToNSColor(self._theme["glyphViewMetricsColor"])
-        colorMetricsTitles = drawing.colorToNSColor(self._theme["glyphViewMetricsTitlesColor"])
+        colorMetrics = drawing.colorToNSColor(
+            self._theme.get("glyphViewFontMetricsStrokeColor", self._fallbackColor))
+        colorMetricsTitles = drawing.colorToNSColor(
+            self._theme.get("glyphViewMetricsTitlesColor", self._fallbackColor))
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         drawText = self.getDrawingAttribute_layerName_("showFontVerticalMetricsTitles", layerName) and self._impliedPointSize > 150
         drawing.drawFontVerticalMetrics(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
             drawText=drawText,
             colorMetrics=colorMetrics,
             colorMetricsTitles=colorMetricsTitles,
@@ -383,9 +386,9 @@ class DefconAppKitGlyphThemeNSView(NSView):
         marginColor = drawing.colorToNSColor(self._theme["glyphViewMarginColor"])
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         drawing.drawGlyphMargins(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
             marginColor=marginColor)
 
     @python_method
@@ -399,18 +402,18 @@ class DefconAppKitGlyphThemeNSView(NSView):
         showFill = self.getDrawingAttribute_layerName_("showGlyphFill", layerName)
         showStroke = self.getDrawingAttribute_layerName_("showGlyphStroke", layerName)
         drawing.drawGlyphFillAndStroke(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
-            drawFill=showFill, 
-            drawStroke=showStroke, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
+            drawFill=showFill,
+            drawStroke=showStroke,
             contourFillColor=contourFillColor,
             contourStrokeColor=contourStrokeColor,
             componentFillColor=componentFillColor,
             componentStrokeColor=componentStrokeColor,
             backgroundColor=backgroundColor,
             contourStrokeWidth=strokeWidth)
-            
+
 
     @python_method
     def drawPoints(self, glyph, layerName):
@@ -421,15 +424,18 @@ class DefconAppKitGlyphThemeNSView(NSView):
         colorCurvePointsFill = drawing.colorToNSColor(self._theme["glyphViewCurvePointsFill"])
         colorCurvePointsStroke = drawing.colorToNSColor(self._theme["glyphViewCurvePointsStroke"])
         colorOffCurvePointsFill = drawing.colorToNSColor(self._theme["glyphViewOffCurvePointsFill"])
-        colorOffCurvePointsStroke = drawing.colorToNSColor(self._theme["glyphViewOffCurvePointsStroke"])
+        colorOffCurvePointsStroke = drawing.colorToNSColor(
+            self._theme.get("glyphViewOffCurveCubicPointsStroke", self._fallbackColor))
         colorOffCurveQuadPointsStroke = drawing.colorToNSColor(self._theme["glyphViewOffCurveQuadPointsStroke"])
         colorSmoothPointStroke = drawing.colorToNSColor(self._theme["glyphViewSmoothPointStroke"])
         colorStartPointsArrow = drawing.colorToNSColor(self._theme["glyphViewStartPointsArrowColor"])
         colorOpenStartPointsArrow = drawing.colorToNSColor(self._theme["glyphViewOpenStartPointsArrowColor"])
         colorPointCoordinate = drawing.colorToNSColor(self._theme["glyphViewPointCoordinateColor"])
         colorPointCoordinateBackground = drawing.colorToNSColor(self._theme["glyphViewPointCoordinateBackgroundColor"])
-        colorHandlesStroke = drawing.colorToNSColor(self._theme["glyphViewHandlesStrokeColor"])
-        colorHandlesQuadStroke = drawing.colorToNSColor(self._theme["glyphViewHandlesQuadStrokeColor"])
+        colorHandlesStroke = drawing.colorToNSColor(
+            self._theme.get("glyphViewCubicHandlesStrokeColor", self._fallbackColor))
+        colorHandlesQuadStroke = drawing.colorToNSColor(
+            self._theme.get("glyphViewQuadraticHandlesStrokeColor", self._fallbackColor))
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         pointSizeOffCurve = self._theme["glyphViewOffCurvePointsSize"] * 2
         pointSizeOnCurve = self._theme["glyphViewOncurvePointsSize"] * 2
@@ -438,12 +444,12 @@ class DefconAppKitGlyphThemeNSView(NSView):
         drawOffCurves = self.getDrawingAttribute_layerName_("showGlyphOffCurvePoints", layerName) and self._impliedPointSize > 175
         drawCoordinates = self.getDrawingAttribute_layerName_("showGlyphPointCoordinates", layerName) and self._impliedPointSize > 250
         drawing.drawGlyphPoints(
-            glyph, 
-            self._inverseScale, 
+            glyph,
+            self._inverseScale,
             self._drawingRect,
             drawStartPoint=drawStartPoint,
-            drawOnCurves=drawOnCurves, 
-            drawOffCurves=drawOffCurves, 
+            drawOnCurves=drawOnCurves,
+            drawOffCurves=drawOffCurves,
             drawCoordinates=drawCoordinates,
             colorCornerPointsFill=colorCornerPointsFill,
             colorCornerPointsStroke=colorCornerPointsStroke,
@@ -472,10 +478,10 @@ class DefconAppKitGlyphThemeNSView(NSView):
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         drawText = self._impliedPointSize > 50
         drawing.drawGlyphAnchors(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
-            drawText=drawText, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
+            drawText=drawText,
             color=color,
             textColor=textColor,
             backgroundColor=self._backgroundColor)
@@ -641,8 +647,8 @@ class GlyphView(PlacardScrollView):
         self._subscribeToGlyph(glyph)
         self._glyphView.setGlyph_(glyph)
         self._populatePlacard()
-        
-        
+
+
     def setTheme(self, theme):
         self._glyphView.setTheme(theme)
 

--- a/ThemeManager.roboFontExt/resources/presetThemes/Andy's Theme-RFTheme.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Andy's Theme-RFTheme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.0</real>
 		<real>0.10000000149011612</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.08037952333688736</real>
 		<real>0.6210653185844421</real>
 		<real>0.4446389079093933</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>1.0</real>
@@ -193,7 +193,7 @@
 		<real>0.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>2.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/Connor's Theme.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Connor's Theme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.5</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>1.0</real>
 		<real>0.0</real>
 		<real>0.0</real>
 		<real>0.8</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.1952849911971831</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>1.0</real>
 		<real>0.2</real>
@@ -193,7 +193,7 @@
 		<real>0.8</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.3477715849876404</real>
 		<real>0.3518064618110657</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>3</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>1.0</real>
 		<real>0.6668</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/Dark Candy.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Dark Candy.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.819777397260274</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.14366580979599022</real>
 		<real>0.3672854976309422</real>
@@ -179,7 +179,7 @@
 		<real>0.6645173373287672</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -193,7 +193,7 @@
 		<real>0.7662671232876717</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.1387670697498714</real>
 		<real>0.2287668370187155</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>2.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.11303741289003856</real>
 		<real>0.6854130993150684</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/Frank’s Theme.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Frank’s Theme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.5</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.10455963015556335</real>
 		<real>0.8123719692230225</real>
 		<real>0.6896181106567383</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>1.0</real>
@@ -193,7 +193,7 @@
 		<real>0.501960813999176</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>5.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.9879457950592041</real>
 		<real>1.0</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/Haze.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Haze.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.0</real>
 		<real>0.10000000149011612</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
 		<real>0.4</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.502</real>
@@ -193,7 +193,7 @@
 		<real>0.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>3.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.6</real>
 		<real>0.6</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/Light Candy.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Light Candy.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.819777397260274</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.14366580979599022</real>
 		<real>0.3672854976309422</real>
@@ -179,7 +179,7 @@
 		<real>0.6645173373287672</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -193,7 +193,7 @@
 		<real>0.7662671232876717</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.1387670697498714</real>
 		<real>0.2287668370187155</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>2.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.11303741289003856</real>
 		<real>0.6854130993150684</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/RFDefault-RFTheme.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/RFDefault-RFTheme.roboFontTheme
@@ -135,14 +135,14 @@
       <real>0.5</real>
       <real>1.0</real>
     </array>
-    <key>glyphViewHandlesQuadStrokeColor</key>
+    <key>glyphViewQuadraticHandlesStrokeColor</key>
     <array>
       <real>0.8</real>
       <real>0.8</real>
       <real>0.8</real>
       <real>1.0</real>
     </array>
-    <key>glyphViewHandlesStrokeColor</key>
+    <key>glyphViewCubicHandlesStrokeColor</key>
     <array>
       <real>0.4</real>
       <real>0.4</real>
@@ -179,7 +179,7 @@
       <real>0.0</real>
       <real>0.5</real>
     </array>
-    <key>glyphViewMeasurementsForgroundColor</key>
+    <key>glyphViewMeasurementsForegroundColor</key>
     <array>
       <real>0.0</real>
       <real>1.0</real>
@@ -193,7 +193,7 @@
       <real>0.0</real>
       <real>1.0</real>
     </array>
-    <key>glyphViewMetricsColor</key>
+    <key>glyphViewFontMetricsStrokeColor</key>
     <array>
       <real>0.4</real>
       <real>0.4</real>
@@ -216,7 +216,7 @@
     </array>
     <key>glyphViewOffCurvePointsSize</key>
     <real>3.0</real>
-    <key>glyphViewOffCurvePointsStroke</key>
+    <key>glyphViewOffCurveCubicPointsStroke</key>
     <array>
       <real>1.0</real>
       <real>1.0</real>

--- a/ThemeManager.roboFontExt/resources/presetThemes/Tal's Theme.roboFontTheme
+++ b/ThemeManager.roboFontExt/resources/presetThemes/Tal's Theme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>1.0</real>
 		<real>0.3</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.196078431373</real>
 		<real>0.392156862745</real>
 		<real>1.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>1.0</real>
@@ -193,7 +193,7 @@
 		<real>0.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>3.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>

--- a/buildExtension.py
+++ b/buildExtension.py
@@ -13,7 +13,7 @@ resourcesPath = os.path.join(basePath, "resources")
 B = ExtensionBundle()
 
 B.name = "Theme Manager"
-B.version = "1.0.4"
+B.version = "1.0.5"
 B.developer = "Connor Davenport and Andy Clymer"
 B.developerURL = 'http://www.connordavenport.com/ http://www.andyclymer.com/'
 
@@ -24,7 +24,7 @@ B.addToMenu = [
         'preferredName': 'Theme Manager...',
         'shortKey' : '',
     }]
-    
+
 B.requiresVersionMajor = '3'
 B.requiresVersionMinor = '1'
 B.infoDictionary["html"] = True

--- a/lib/ThemeManager.py
+++ b/lib/ThemeManager.py
@@ -42,15 +42,15 @@ THEMEKEYS = [
     ("glyphViewTangentPointsFill", "Tangent Fill Color", tuple),
     ("glyphViewTangentPointsStroke", "Tangent Stroke Color", tuple),
     ("glyphViewOffCurvePointsFill", "Offcurve Fill Color", tuple),
-    ("glyphViewOffCurvePointsStroke", "Offcurve Stroke Color (Cubic Beziers, PostScript)", tuple),
+    ("glyphViewOffCurveCubicPointsStroke", "Offcurve Stroke Color (Cubic Beziers, PostScript)", tuple),
     ("glyphViewOffCurveQuadPointsStroke", "Offcurve Stroke Color (Quadratic Beziers, TrueType)", tuple),
     ("glyphViewSmoothPointStroke", "Smooth Point Color", tuple),
     ("glyphViewComponentFillColor", "Component Fill Color", tuple),
     ("glyphViewComponentStrokeColor", "Component Stroke Color", tuple),
     ("glyphViewComponentInfoColor", "Component Info Text Color", tuple),
     ("glyphViewImageInfoColor", "Image Info Text Color", tuple),
-    ("glyphViewHandlesStrokeColor", "Handle Stroke Color (Cubic Beziers, PostScript)", tuple),
-    ("glyphViewHandlesQuadStrokeColor", "Handle Stroke Color (Quadratic Beziers, TrueType)", tuple),
+    ("glyphViewCubicHandlesStrokeColor", "Handle Stroke Color (Cubic Beziers, PostScript)", tuple),
+    ("glyphViewQuadraticHandlesStrokeColor", "Handle Stroke Color (Quadratic Beziers, TrueType)", tuple),
     ("glyphViewStartPointsArrowColor", "Start Point Arrow Color for closed contour", tuple),
     ("glyphViewOpenStartPointsArrowColor", "Start Point Arrow Color for an open contour", tuple),
     ("glyphViewSelectionColor", "Selection Color", tuple),
@@ -64,13 +64,13 @@ THEMEKEYS = [
     ("glyphViewAnchorColor", "Anchor Color", tuple),
     ("glyphViewAnchorTextColor", "Anchor Text Color", tuple),
     ("glyphViewMarginColor", "Margins Background Color", tuple),
-    ("glyphViewMetricsColor", "Vertical Metrics Color", tuple),
+    ("glyphViewFontMetricsStrokeColor", "Vertical Metrics Color", tuple),
     ("glyphViewMetricsTitlesColor", "Vertical Metrics Titles Color", tuple),
     ("glyphViewGridColor", "Grid Color", tuple),
     ("glyphViewBitmapColor", "Bitmap Color", tuple),
     ("glyphViewOutlineErrorsColor", "Line Straightness Indicator Color", tuple),
     ("glyphViewMeasurementsTextColor", "Measurements Text Color", tuple),
-    ("glyphViewMeasurementsForgroundColor", "Measurements Line Color", tuple),
+    ("glyphViewMeasurementsForegroundColor", "Measurements Line Color", tuple),
     ("glyphViewMeasurementsBackgroundColor", "Measurements Secondary Line Color", tuple),
     ("glyphViewContourIndexColor", "Contour Index Text Color", tuple),
     ("glyphViewSegmentIndexColor", "Segment Index Text Color", tuple),
@@ -241,13 +241,14 @@ class ThemeManager(BaseWindowController):
         # Collect the theme data for the selected theme and set it to the editingList
         if self.debug: print("setEditingList")
         listItems = []
+        fallbackColor = [.5, .5, .5, .5]
         for nameKey, name, valueType in THEMEKEYS:
             if valueType == tuple:
-                color = theme[nameKey]
+                color = theme.get(nameKey, fallbackColor)
                 listItem = {
-                        'color' : NSColor.colorWithCalibratedRed_green_blue_alpha_(*color),
-                        'name'  : name,
-                        'nameKey' : nameKey}
+                    'color': NSColor.colorWithCalibratedRed_green_blue_alpha_(*color),
+                    'name': name,
+                    'nameKey': nameKey}
                 listItems.append(listItem)
             else:
                 value = theme[nameKey]

--- a/lib/defconAppKitBranch/glyphView.py
+++ b/lib/defconAppKitBranch/glyphView.py
@@ -50,6 +50,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
         self._verticalCenterYBuffer = 100
 
         self._backgroundColor = NSColor.whiteColor()
+        self._fallbackColor = [.5, .5, .5, .5]
 
         return self
 
@@ -158,7 +159,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
     # ---------------
     # Display Control
     # ---------------
-    
+
     @python_method
     def setTheme(self, theme):
         self._theme = theme
@@ -280,7 +281,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
 
         yOffset = self._verticalCenterYBuffer * self._inverseScale
         yOffset -= self._descender
-        
+
         # @@@
         yOffset -= 270
         xOffset += 130
@@ -342,7 +343,7 @@ class DefconAppKitGlyphThemeNSView(NSView):
     def drawBackground(self):
         if "glyphViewBackgroundColor" in self._theme:
             self._backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
-        else: 
+        else:
             self._backgroundColor = NSColor.whiteColor()
         self._backgroundColor.set()
         NSRectFill(self.bounds())
@@ -365,14 +366,16 @@ class DefconAppKitGlyphThemeNSView(NSView):
 
     @python_method
     def drawVerticalMetrics(self, glyph, layerName):
-        colorMetrics = drawing.colorToNSColor(self._theme["glyphViewMetricsColor"])
-        colorMetricsTitles = drawing.colorToNSColor(self._theme["glyphViewMetricsTitlesColor"])
+        colorMetrics = drawing.colorToNSColor(
+            self._theme.get("glyphViewFontMetricsStrokeColor", self._fallbackColor))
+        colorMetricsTitles = drawing.colorToNSColor(
+            self._theme.get("glyphViewMetricsTitlesColor", self._fallbackColor))
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         drawText = self.getDrawingAttribute_layerName_("showFontVerticalMetricsTitles", layerName) and self._impliedPointSize > 150
         drawing.drawFontVerticalMetrics(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
             drawText=drawText,
             colorMetrics=colorMetrics,
             colorMetricsTitles=colorMetricsTitles,
@@ -383,9 +386,9 @@ class DefconAppKitGlyphThemeNSView(NSView):
         marginColor = drawing.colorToNSColor(self._theme["glyphViewMarginColor"])
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         drawing.drawGlyphMargins(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
             marginColor=marginColor)
 
     @python_method
@@ -399,18 +402,18 @@ class DefconAppKitGlyphThemeNSView(NSView):
         showFill = self.getDrawingAttribute_layerName_("showGlyphFill", layerName)
         showStroke = self.getDrawingAttribute_layerName_("showGlyphStroke", layerName)
         drawing.drawGlyphFillAndStroke(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
-            drawFill=showFill, 
-            drawStroke=showStroke, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
+            drawFill=showFill,
+            drawStroke=showStroke,
             contourFillColor=contourFillColor,
             contourStrokeColor=contourStrokeColor,
             componentFillColor=componentFillColor,
             componentStrokeColor=componentStrokeColor,
             backgroundColor=backgroundColor,
             contourStrokeWidth=strokeWidth)
-            
+
 
     @python_method
     def drawPoints(self, glyph, layerName):
@@ -421,15 +424,18 @@ class DefconAppKitGlyphThemeNSView(NSView):
         colorCurvePointsFill = drawing.colorToNSColor(self._theme["glyphViewCurvePointsFill"])
         colorCurvePointsStroke = drawing.colorToNSColor(self._theme["glyphViewCurvePointsStroke"])
         colorOffCurvePointsFill = drawing.colorToNSColor(self._theme["glyphViewOffCurvePointsFill"])
-        colorOffCurvePointsStroke = drawing.colorToNSColor(self._theme["glyphViewOffCurvePointsStroke"])
+        colorOffCurvePointsStroke = drawing.colorToNSColor(
+            self._theme.get("glyphViewOffCurveCubicPointsStroke", self._fallbackColor))
         colorOffCurveQuadPointsStroke = drawing.colorToNSColor(self._theme["glyphViewOffCurveQuadPointsStroke"])
         colorSmoothPointStroke = drawing.colorToNSColor(self._theme["glyphViewSmoothPointStroke"])
         colorStartPointsArrow = drawing.colorToNSColor(self._theme["glyphViewStartPointsArrowColor"])
         colorOpenStartPointsArrow = drawing.colorToNSColor(self._theme["glyphViewOpenStartPointsArrowColor"])
         colorPointCoordinate = drawing.colorToNSColor(self._theme["glyphViewPointCoordinateColor"])
         colorPointCoordinateBackground = drawing.colorToNSColor(self._theme["glyphViewPointCoordinateBackgroundColor"])
-        colorHandlesStroke = drawing.colorToNSColor(self._theme["glyphViewHandlesStrokeColor"])
-        colorHandlesQuadStroke = drawing.colorToNSColor(self._theme["glyphViewHandlesQuadStrokeColor"])
+        colorHandlesStroke = drawing.colorToNSColor(
+            self._theme.get("glyphViewCubicHandlesStrokeColor", self._fallbackColor))
+        colorHandlesQuadStroke = drawing.colorToNSColor(
+            self._theme.get("glyphViewQuadraticHandlesStrokeColor", self._fallbackColor))
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         pointSizeOffCurve = self._theme["glyphViewOffCurvePointsSize"] * 2
         pointSizeOnCurve = self._theme["glyphViewOncurvePointsSize"] * 2
@@ -438,12 +444,12 @@ class DefconAppKitGlyphThemeNSView(NSView):
         drawOffCurves = self.getDrawingAttribute_layerName_("showGlyphOffCurvePoints", layerName) and self._impliedPointSize > 175
         drawCoordinates = self.getDrawingAttribute_layerName_("showGlyphPointCoordinates", layerName) and self._impliedPointSize > 250
         drawing.drawGlyphPoints(
-            glyph, 
-            self._inverseScale, 
+            glyph,
+            self._inverseScale,
             self._drawingRect,
             drawStartPoint=drawStartPoint,
-            drawOnCurves=drawOnCurves, 
-            drawOffCurves=drawOffCurves, 
+            drawOnCurves=drawOnCurves,
+            drawOffCurves=drawOffCurves,
             drawCoordinates=drawCoordinates,
             colorCornerPointsFill=colorCornerPointsFill,
             colorCornerPointsStroke=colorCornerPointsStroke,
@@ -472,10 +478,10 @@ class DefconAppKitGlyphThemeNSView(NSView):
         backgroundColor = drawing.colorToNSColor(self._theme["glyphViewBackgroundColor"])
         drawText = self._impliedPointSize > 50
         drawing.drawGlyphAnchors(
-            glyph, 
-            self._inverseScale, 
-            self._drawingRect, 
-            drawText=drawText, 
+            glyph,
+            self._inverseScale,
+            self._drawingRect,
+            drawText=drawText,
             color=color,
             textColor=textColor,
             backgroundColor=self._backgroundColor)
@@ -641,8 +647,8 @@ class GlyphView(PlacardScrollView):
         self._subscribeToGlyph(glyph)
         self._glyphView.setGlyph_(glyph)
         self._populatePlacard()
-        
-        
+
+
     def setTheme(self, theme):
         self._glyphView.setTheme(theme)
 

--- a/resources/presetThemes/Andy's Theme-RFTheme.roboFontTheme
+++ b/resources/presetThemes/Andy's Theme-RFTheme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.0</real>
 		<real>0.10000000149011612</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.08037952333688736</real>
 		<real>0.6210653185844421</real>
 		<real>0.4446389079093933</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>1.0</real>
@@ -193,7 +193,7 @@
 		<real>0.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>2.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>

--- a/resources/presetThemes/Connor's Theme.roboFontTheme
+++ b/resources/presetThemes/Connor's Theme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.5</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>1.0</real>
 		<real>0.0</real>
 		<real>0.0</real>
 		<real>0.8</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.1952849911971831</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>1.0</real>
 		<real>0.2</real>
@@ -193,7 +193,7 @@
 		<real>0.8</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.3477715849876404</real>
 		<real>0.3518064618110657</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>3</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>1.0</real>
 		<real>0.6668</real>

--- a/resources/presetThemes/Dark Candy.roboFontTheme
+++ b/resources/presetThemes/Dark Candy.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.819777397260274</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.14366580979599022</real>
 		<real>0.3672854976309422</real>
@@ -179,7 +179,7 @@
 		<real>0.6645173373287672</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -193,7 +193,7 @@
 		<real>0.7662671232876717</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.1387670697498714</real>
 		<real>0.2287668370187155</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>2.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.11303741289003856</real>
 		<real>0.6854130993150684</real>

--- a/resources/presetThemes/Frank’s Theme.roboFontTheme
+++ b/resources/presetThemes/Frank’s Theme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.5</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.10455963015556335</real>
 		<real>0.8123719692230225</real>
 		<real>0.6896181106567383</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>1.0</real>
@@ -193,7 +193,7 @@
 		<real>0.501960813999176</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>5.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.9879457950592041</real>
 		<real>1.0</real>

--- a/resources/presetThemes/Haze.roboFontTheme
+++ b/resources/presetThemes/Haze.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.0</real>
 		<real>0.10000000149011612</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
 		<real>0.4</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.502</real>
@@ -193,7 +193,7 @@
 		<real>0.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.4</real>
 		<real>0.4</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>3.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.6</real>
 		<real>0.6</real>

--- a/resources/presetThemes/Light Candy.roboFontTheme
+++ b/resources/presetThemes/Light Candy.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>0.819777397260274</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>0.8</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.14366580979599022</real>
 		<real>0.3672854976309422</real>
@@ -179,7 +179,7 @@
 		<real>0.6645173373287672</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -193,7 +193,7 @@
 		<real>0.7662671232876717</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.1387670697498714</real>
 		<real>0.2287668370187155</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>2.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.11303741289003856</real>
 		<real>0.6854130993150684</real>

--- a/resources/presetThemes/RFDefault-RFTheme.roboFontTheme
+++ b/resources/presetThemes/RFDefault-RFTheme.roboFontTheme
@@ -135,14 +135,14 @@
       <real>0.5</real>
       <real>1.0</real>
     </array>
-    <key>glyphViewHandlesQuadStrokeColor</key>
+    <key>glyphViewQuadraticHandlesStrokeColor</key>
     <array>
       <real>0.8</real>
       <real>0.8</real>
       <real>0.8</real>
       <real>1.0</real>
     </array>
-    <key>glyphViewHandlesStrokeColor</key>
+    <key>glyphViewCubicHandlesStrokeColor</key>
     <array>
       <real>0.4</real>
       <real>0.4</real>
@@ -179,7 +179,7 @@
       <real>0.0</real>
       <real>0.5</real>
     </array>
-    <key>glyphViewMeasurementsForgroundColor</key>
+    <key>glyphViewMeasurementsForegroundColor</key>
     <array>
       <real>0.0</real>
       <real>1.0</real>
@@ -193,7 +193,7 @@
       <real>0.0</real>
       <real>1.0</real>
     </array>
-    <key>glyphViewMetricsColor</key>
+    <key>glyphViewFontMetricsStrokeColor</key>
     <array>
       <real>0.4</real>
       <real>0.4</real>
@@ -216,7 +216,7 @@
     </array>
     <key>glyphViewOffCurvePointsSize</key>
     <real>3.0</real>
-    <key>glyphViewOffCurvePointsStroke</key>
+    <key>glyphViewOffCurveCubicPointsStroke</key>
     <array>
       <real>1.0</real>
       <real>1.0</real>

--- a/resources/presetThemes/Tal's Theme.roboFontTheme
+++ b/resources/presetThemes/Tal's Theme.roboFontTheme
@@ -135,14 +135,14 @@
 		<real>1.0</real>
 		<real>0.3</real>
 	</array>
-	<key>glyphViewHandlesQuadStrokeColor</key>
+	<key>glyphViewQuadraticHandlesStrokeColor</key>
 	<array>
 		<real>0.196078431373</real>
 		<real>0.392156862745</real>
 		<real>1.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewHandlesStrokeColor</key>
+	<key>glyphViewCubicHandlesStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -179,7 +179,7 @@
 		<real>0.0</real>
 		<real>0.5</real>
 	</array>
-	<key>glyphViewMeasurementsForgroundColor</key>
+	<key>glyphViewMeasurementsForegroundColor</key>
 	<array>
 		<real>0.0</real>
 		<real>1.0</real>
@@ -193,7 +193,7 @@
 		<real>0.0</real>
 		<real>1.0</real>
 	</array>
-	<key>glyphViewMetricsColor</key>
+	<key>glyphViewFontMetricsStrokeColor</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>
@@ -216,7 +216,7 @@
 	</array>
 	<key>glyphViewOffCurvePointsSize</key>
 	<real>3.0</real>
-	<key>glyphViewOffCurvePointsStroke</key>
+	<key>glyphViewOffCurveCubicPointsStroke</key>
 	<array>
 		<real>0.0</real>
 		<real>0.0</real>


### PR DESCRIPTION
I noticed that setting the color of BCP handles via Theme Manager did not work. The reason for this is that some color keys have been updated within RF:
```
glyphViewHandlesStrokeColor: glyphViewCubicHandlesStrokeColor
glyphViewHandlesQuadStrokeColor: glyphViewQuadraticHandlesStrokeColor
glyphViewOffCurvePointsStroke: glyphViewOffCurveCubicPointsStroke
glyphViewMetricsColor: glyphViewFontMetricsStrokeColor
glyphViewMeasurementsForgroundColor: glyphViewMeasurementsForegroundColor
```

I ran into issues with existing themes requesting outdated keys, which is why I implemented a fallback system — any colors not found by a given key are re-set to 50% grey.

The fallback system works by using the `dict.get(key, fallback)` method (instead of `dict['key']`), and currently only is implemented for the changed keys. Please let me know if I should make it consistent and extend the same approach to all the other color keys.